### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,6 +2,9 @@ name: Docker
 run-name: Docker image creation
 on:
   workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
 env:
   DOCKER_IMAGE_BASE: ghcr.io/jaumoso/homelab-dashboard
   DOCKER_IMAGE_TAG: latest


### PR DESCRIPTION
Potential fix for [https://github.com/Jaumoso/homelab-dashboard/security/code-scanning/7](https://github.com/Jaumoso/homelab-dashboard/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily needs `contents: read` to check out the code and possibly `packages: write` to publish the Docker image to the GitHub Container Registry. We will also ensure no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
